### PR TITLE
update scheduler.lua to handle if error is nil

### DIFF
--- a/data/shared/citizen/scripting/lua/scheduler.lua
+++ b/data/shared/citizen/scripting/lua/scheduler.lua
@@ -472,7 +472,7 @@ local function doStackFormat(err)
 	local fst = FormatStackTrace()
 	
 	-- already recovering from an error
-	if not fst then
+	if not fst or not err then
 		return nil
 	end
 


### PR DESCRIPTION
Current behavior produces an error in scheduler.lua and this commit fixes that.

### Goal of this PR
<!-- Concise explanation of what this PR meant to achieve -->
wasabi_bridge + ox_target produced an error -that was nil somehow causing scheduler.lua to throw an error.


### How is this PR achieving the goal
Resolves a nil value not being handled.


### This PR applies to the following area(s)
<!-- Add any that applies, e.g.: FiveM, RedM, Server, Natives, FxDK, ScRT: Lua, ScRT: C#, ScRT: JS, etc. -->
FiveM

### Successfully tested on
<!-- Add any that is applicable, remove any that aren't. -->

**Game builds:** .. 

**Platforms:** Windows, Linux


### Checklist
<!-- Mark all points with x that apply, i.e.: [x]. -->

- [x] Code compiles and has been tested successfully.
- [x] Code explains itself well and/or is documented.
- [x] My commit message explains what the changes do and what they are for.
- [x] No extra compilation warnings are added by these changes.


### Fixes issues
<!-- Add any issue that this PR fixes with: `fixes #123`, `resolves #234`, `closes #345`. -->


